### PR TITLE
Fixes #26 - CMake version issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19.0)
+cmake_minimum_required(VERSION 3.13)
 project (Matrix CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
The CMake version has been bumped down from (3.19.0) to (3.13).
This should support majority of OSs.