### PR TITLE
overloads init() method for double, std::string, std::vector<double> …

### DIFF
--- a/include/matrix_operations.hpp
+++ b/include/matrix_operations.hpp
@@ -73,6 +73,44 @@ Matrix MatrixOp::init(std::vector<std::vector<std::string>> vec) {
     return result;
 }
 
+/// Method to initialize values of a Matrix object using a double
+Matrix MatrixOp::init(double d) {
+    Matrix result;
+    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1);
+    (*vec_d)[0].push_back(d);
+    result.double_mat = *vec_d;
+    result.to_string();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a string
+Matrix MatrixOp::init(std::string s) {
+    Matrix result;
+    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1);
+    (*vec_s)[0].push_back(s);
+    result.str_mat = *vec_s;
+    result.to_double();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a double vector
+Matrix MatrixOp::init(std::vector<double> inner_d) {
+    Matrix result;
+    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1, inner_d);
+    result.double_mat = *vec_d;
+    result.to_string();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a string vector
+Matrix MatrixOp::init(std::vector<std::string> inner_s) {
+    Matrix result;
+    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1, inner_s);
+    result.str_mat = *vec_s;
+    result.to_double();
+    return result;
+}
+
 /// Method to concatenate/join two Matrix objects
 Matrix MatrixOp::concatenate(Matrix mat1, Matrix mat2, std::string dim) {
     if (dim == "column") {


### PR DESCRIPTION
…and std::vector<std::string>

# Description

Overloads init() method for double, std::string, std::vector<double> and std::vector<std::string> such that simple 1 row matrices can be formed from it. Uses new keyword to allocate the 2D vector being used for the Matrix and assigns as per previous overloads.

Fixes # (issue)
61
## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update



# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
