### PR TITLE
Overload init(). Issue #61

### DIFF
--- a/include/matrix_operations.hpp
+++ b/include/matrix_operations.hpp
@@ -73,6 +73,44 @@ Matrix MatrixOp::init(std::vector<std::vector<std::string>> vec) {
     return result;
 }
 
+/// Method to initialize values of a Matrix object using a double
+Matrix MatrixOp::init(double d) {
+    Matrix result;
+    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1);
+    (*vec_d)[0].push_back(d);
+    result.double_mat = *vec_d;
+    result.to_string();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a string
+Matrix MatrixOp::init(std::string s) {
+    Matrix result;
+    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1);
+    (*vec_s)[0].push_back(s);
+    result.str_mat = *vec_s;
+    result.to_double();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a double vector
+Matrix MatrixOp::init(std::vector<double> inner_d) {
+    Matrix result;
+    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1, inner_d);
+    result.double_mat = *vec_d;
+    result.to_string();
+    return result;
+}
+
+/// Method to initialize values of a Matrix object using a string vector
+Matrix MatrixOp::init(std::vector<std::string> inner_s) {
+    Matrix result;
+    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1, inner_s);
+    result.str_mat = *vec_s;
+    result.to_double();
+    return result;
+}
+
 /// Method to concatenate/join two Matrix objects
 Matrix MatrixOp::concatenate(Matrix mat1, Matrix mat2, std::string dim) {
     if (dim == "column") {

--- a/include/matrix_operations.hpp
+++ b/include/matrix_operations.hpp
@@ -11,6 +11,10 @@ class MatrixOp {
   public:
     Matrix init(std::vector<std::vector<double>>);
     Matrix init(std::vector<std::vector<std::string>>);
+    Matrix init(double d);
+    Matrix init(std::string s);
+    Matrix init(std::vector<double> inner_d);
+    Matrix init(std::vector<std::string> inner_s);
     Matrix concatenate(Matrix, Matrix, std::string);
     Matrix matmul(Matrix, Matrix);
     Matrix zeros(int, int);

--- a/include/matrix_operations.hpp
+++ b/include/matrix_operations.hpp
@@ -11,10 +11,10 @@ class MatrixOp {
   public:
     Matrix init(std::vector<std::vector<double>>);
     Matrix init(std::vector<std::vector<std::string>>);
-    Matrix init(double d);
-    Matrix init(std::string s);
-    Matrix init(std::vector<double> inner_d);
-    Matrix init(std::vector<std::string> inner_s);
+    Matrix init(double);
+    Matrix init(std::string);
+    Matrix init(std::vector<double>);
+    Matrix init(std::vector<std::string>);
     Matrix concatenate(Matrix, Matrix, std::string);
     Matrix matmul(Matrix, Matrix);
     Matrix zeros(int, int);
@@ -80,9 +80,9 @@ Matrix MatrixOp::init(std::vector<std::vector<std::string>> vec) {
 /// Method to initialize values of a Matrix object using a double
 Matrix MatrixOp::init(double d) {
     Matrix result;
-    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1);
-    (*vec_d)[0].push_back(d);
-    result.double_mat = *vec_d;
+    std::vector<std::vector<double>> vec_d(1);
+    vec_d[0].push_back(d);
+    result.double_mat = vec_d;
     result.to_string();
     return result;
 }
@@ -90,9 +90,9 @@ Matrix MatrixOp::init(double d) {
 /// Method to initialize values of a Matrix object using a string
 Matrix MatrixOp::init(std::string s) {
     Matrix result;
-    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1);
-    (*vec_s)[0].push_back(s);
-    result.str_mat = *vec_s;
+    std::vector<std::vector<std::string>> vec_s(1);
+    vec_s[0].push_back(s);
+    result.str_mat = vec_s;
     result.to_double();
     return result;
 }
@@ -100,8 +100,8 @@ Matrix MatrixOp::init(std::string s) {
 /// Method to initialize values of a Matrix object using a double vector
 Matrix MatrixOp::init(std::vector<double> inner_d) {
     Matrix result;
-    std::vector<std::vector<double>> * vec_d = new std::vector<std::vector<double>>(1, inner_d);
-    result.double_mat = *vec_d;
+    std::vector<std::vector<double>> vec_d(1, inner_d);
+    result.double_mat = vec_d;
     result.to_string();
     return result;
 }
@@ -109,8 +109,8 @@ Matrix MatrixOp::init(std::vector<double> inner_d) {
 /// Method to initialize values of a Matrix object using a string vector
 Matrix MatrixOp::init(std::vector<std::string> inner_s) {
     Matrix result;
-    std::vector<std::vector<std::string>> * vec_s = new std::vector<std::vector<std::string>>(1, inner_s);
-    result.str_mat = *vec_s;
+    std::vector<std::vector<std::string>> vec_s(1, inner_s);
+    result.str_mat = vec_s;
     result.to_double();
     return result;
 }

--- a/tests/initialization_tests.hpp
+++ b/tests/initialization_tests.hpp
@@ -55,4 +55,79 @@ TEST(MatrixInitTest, CreatesMatrixFromCSV) {
     EXPECT_EQ(mat, test_with);
 }
 
+TEST(MatrixInitTest, CreatesMatrixObjectFromString1DVector) {
+    std::vector<std::string> vec;
+    Matrix mat;
+
+    EXPECT_EQ(typeid(mat).name(), typeid(matrix.init(vec)).name());
+}
+
+TEST(MatrixInitTest, CreatesMatrixObjectFromDouble1DVector) {
+    std::vector<double> vec;
+    Matrix mat;
+
+    EXPECT_EQ(typeid(mat).name(), typeid(matrix.init(vec)).name());
+}
+
+TEST(MatrixInitTest, CreatesMatrixObjectFromString) {
+    Matrix mat;
+
+    EXPECT_EQ(typeid(mat).name(), typeid(matrix.init("")).name());
+}
+
+TEST(MatrixInitTest, CreatesMatrixObjectFromDouble) {
+    Matrix mat;
+
+    EXPECT_EQ(typeid(mat).name(), typeid(matrix.init(0)).name());
+}
+
+TEST(MatrixInitTest, InitializesMatrixFromString1DVector) {
+    std::vector<std::string> vec;
+    vec.push_back("1");
+    vec.push_back("2");
+    vec.push_back("3");
+
+    Matrix mat = matrix.init(vec);
+
+    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    test_with = test_with.slice(0, 1, 0, test_with.col_length());
+
+    EXPECT_EQ(mat, test_with);
+}
+
+TEST(MatrixInitTest, InitializesMatrixFromDouble1DVector) {
+    std::vector<double> vec;
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+
+    Matrix mat = matrix.init(vec);
+    
+    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    test_with = test_with.slice(0, 1, 0, test_with.col_length());
+    test_with.to_double();
+
+    EXPECT_EQ(mat, test_with);
+}
+
+TEST(MatrixInitTest, InitializesMatrixFromString) {
+    
+    Matrix mat = matrix.init("1");
+
+    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    test_with = test_with.slice(0, 1, 0, 1);
+
+    EXPECT_EQ(mat, test_with);
+}
+
+TEST(MatrixInitTest, InitializesMatrixFromDouble) {
+    
+    Matrix mat = matrix.init(1);
+
+    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    test_with = test_with.slice(0, 1, 0, 1);
+    test_with.to_double();
+
+    EXPECT_EQ(mat, test_with);
+}
 } // namespace

--- a/tests/initialization_tests.hpp
+++ b/tests/initialization_tests.hpp
@@ -111,7 +111,6 @@ TEST(MatrixInitTest, InitializesMatrixFromDouble1DVector) {
 }
 
 TEST(MatrixInitTest, InitializesMatrixFromString) {
-    
     Matrix mat = matrix.init("1");
 
     Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');
@@ -121,7 +120,6 @@ TEST(MatrixInitTest, InitializesMatrixFromString) {
 }
 
 TEST(MatrixInitTest, InitializesMatrixFromDouble) {
-    
     Matrix mat = matrix.init(1);
 
     Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');

--- a/tests/initialization_tests.hpp
+++ b/tests/initialization_tests.hpp
@@ -89,7 +89,7 @@ TEST(MatrixInitTest, InitializesMatrixFromString1DVector) {
 
     Matrix mat = matrix.init(vec);
 
-    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');
     test_with = test_with.slice(0, 1, 0, test_with.col_length());
 
     EXPECT_EQ(mat, test_with);
@@ -103,7 +103,7 @@ TEST(MatrixInitTest, InitializesMatrixFromDouble1DVector) {
 
     Matrix mat = matrix.init(vec);
     
-    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');
     test_with = test_with.slice(0, 1, 0, test_with.col_length());
     test_with.to_double();
 
@@ -114,7 +114,7 @@ TEST(MatrixInitTest, InitializesMatrixFromString) {
     
     Matrix mat = matrix.init("1");
 
-    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');
     test_with = test_with.slice(0, 1, 0, 1);
 
     EXPECT_EQ(mat, test_with);
@@ -124,7 +124,7 @@ TEST(MatrixInitTest, InitializesMatrixFromDouble) {
     
     Matrix mat = matrix.init(1);
 
-    Matrix test_with = matrix.genfromtxt('test_dataset.csv', ',');
+    Matrix test_with = matrix.genfromtxt("test_dataset.csv", ',');
     test_with = test_with.slice(0, 1, 0, 1);
     test_with.to_double();
 


### PR DESCRIPTION
# Description

Overloads init() method for double, std::string, std::vector<std::string> and std::vector<double>. The overloaded functions mirror already existing ones but provide the functionality to create matrices with 1 row. The keyword new is used in order to allocate sufficient memory from within the function.

Fixes # 61

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas