### PR TITLE
Fixes Equality operation

### DIFF
--- a/include/matrix_basic.hpp
+++ b/include/matrix_basic.hpp
@@ -527,10 +527,17 @@ Matrix Matrix::operator-() {
 }
 
 bool Matrix::operator==(Matrix mat) const {
-    if (double_mat == mat.double_mat)
-        return true;
-    else
-        return false;
+    if (if_double && mat.if_double) {
+        if (double_mat == mat.double_mat)
+            return true;
+        else
+            return false;
+    } else {
+        if (str_mat == mat.str_mat)
+            return true;
+        else
+            return false;
+    }
 }
 
 #endif /* _matrix_hpp_ */


### PR DESCRIPTION
# Description

Equality operation was not previously working for Matrix objects which were not converted to double using to_double() method and were being used as std::string only.

This PR fixes the above bug.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes